### PR TITLE
tasks: misc changes to sorting logic

### DIFF
--- a/src/store/features/display/display-selectors.ts
+++ b/src/store/features/display/display-selectors.ts
@@ -1,5 +1,5 @@
 import { RootState } from '~/store/store';
-import { TaskDisplayField } from './display-slice';
+import { TaskDisplayField, SortDirection } from './display-slice';
 import { createSelector } from '@reduxjs/toolkit';
 import { selectAllTasks } from '../tasks/tasks-selectors';
 import { TaskObject } from '~/components/tasks/types';
@@ -15,7 +15,7 @@ export const selectIsFieldVisible =
 export const selectSortBy = (state: RootState): TaskDisplayField =>
   state.display.sortBy;
 
-export const selectSortDirection = (state: RootState): 'asc' | 'desc' =>
+export const selectSortDirection = (state: RootState): SortDirection =>
   state.display.sortDirection;
 
 export const selectFieldLabels = (): Record<TaskDisplayField, string> => ({

--- a/src/store/features/display/display-slice.ts
+++ b/src/store/features/display/display-slice.ts
@@ -10,10 +10,12 @@ export type TaskDisplayField =
   | 'updatedAt'
   | 'labels';
 
+export type SortDirection = 'asc' | 'desc';
+
 export interface DisplayState {
   visibleFields: TaskDisplayField[];
   sortBy: TaskDisplayField;
-  sortDirection: 'asc' | 'desc';
+  sortDirection: SortDirection;
 }
 
 const defaultVisibleFields: TaskDisplayField[] = [
@@ -61,7 +63,7 @@ export const displaySlice = createSlice({
     setSortBy: (state, action: PayloadAction<TaskDisplayField>) => {
       state.sortBy = action.payload;
     },
-    setSortDirection: (state, action: PayloadAction<'asc' | 'desc'>) => {
+    setSortDirection: (state, action: PayloadAction<SortDirection>) => {
       state.sortDirection = action.payload;
     },
     toggleSortDirection: (state) => {

--- a/src/store/features/display/display-slice.ts
+++ b/src/store/features/display/display-slice.ts
@@ -18,20 +18,22 @@ export interface DisplayState {
   sortDirection: SortDirection;
 }
 
-const defaultVisibleFields: TaskDisplayField[] = [
-  'priority',
-  'id',
-  'status',
-  'title',
-  'assignee',
-  'createdAt',
-  'updatedAt',
-];
-
-const initialState: DisplayState = {
-  visibleFields: defaultVisibleFields,
+const defaultDisplayConfig: DisplayState = {
+  visibleFields: [
+    'priority',
+    'id',
+    'status',
+    'title',
+    'assignee',
+    'createdAt',
+    'updatedAt',
+  ],
   sortBy: 'createdAt',
   sortDirection: 'desc',
+};
+
+const initialState: DisplayState = {
+  ...defaultDisplayConfig,
 };
 
 export const displaySlice = createSlice({
@@ -70,9 +72,9 @@ export const displaySlice = createSlice({
       state.sortDirection = state.sortDirection === 'asc' ? 'desc' : 'asc';
     },
     resetToDefault: (state) => {
-      state.visibleFields = [...defaultVisibleFields];
-      state.sortBy = 'title';
-      state.sortDirection = 'asc';
+      state.visibleFields = [...defaultDisplayConfig.visibleFields];
+      state.sortBy = defaultDisplayConfig.sortBy;
+      state.sortDirection = defaultDisplayConfig.sortDirection;
     },
   },
 });

--- a/src/store/features/display/display-slice.ts
+++ b/src/store/features/display/display-slice.ts
@@ -30,8 +30,8 @@ const defaultVisibleFields: TaskDisplayField[] = [
 
 const initialState: DisplayState = {
   visibleFields: defaultVisibleFields,
-  sortBy: 'title',
-  sortDirection: 'asc',
+  sortBy: 'createdAt',
+  sortDirection: 'desc',
 };
 
 export const displaySlice = createSlice({


### PR DESCRIPTION
Made the following changes!

1) extracted `asc` and `desc` into the `SortDirection` type

2) used `createdAt` & `desc` for the new initial sort state, which allows users to see the latest created tasks first
<img width="1440" height="859" alt="Screenshot 2025-08-27 at 5 31 12 PM" src="https://github.com/user-attachments/assets/598c69fd-e659-4606-af86-52f73245a861" />

3) eliminated multiple definitions of initial sort state
