### PR TITLE
tasks: misc changes to sorting logic 2

### DIFF
--- a/src/components/tasks/display/task-display-dropdown.tsx
+++ b/src/components/tasks/display/task-display-dropdown.tsx
@@ -146,7 +146,8 @@ export function TaskDisplayDropdown() {
                 <Button
                   variant="outline"
                   size="sm"
-                  className="h-6 px-1 text-xs w-16">
+                  className="h-6 px-1 text-xs w-16"
+                  tooltip={`Sort by ${fieldLabels[sortBy].toLowerCase()}`}>
                   <span>{fieldLabels[sortBy]}</span>
                 </Button>
               </DropdownMenuTrigger>
@@ -169,6 +170,8 @@ export function TaskDisplayDropdown() {
               }
               className="size-6 p-0 shrink-0"
               onClick={handleToggleSortDirection}
+              tooltip={`Sort ${sortDirection === 'asc' ? 'ascending' : 'descending'}`}
+              aria-label={`Sort ${sortDirection === 'asc' ? 'ascending' : 'descending'}`}
             />
           </div>
         </div>

--- a/src/components/tasks/task-commands.tsx
+++ b/src/components/tasks/task-commands.tsx
@@ -16,10 +16,47 @@ import type { CommandCreator, CommandData } from '~/components/commands/types';
 import {
   clearSelectedTask,
   deleteTask,
-  selectNextTask,
-  selectPreviousTask,
+  selectTaskById,
 } from '~/store/features/tasks/tasks-slice';
+import { selectSortedTasks } from '~/store/features/display/display-selectors';
+import { selectSelectedTaskId } from '~/store/features/tasks/tasks-selectors';
 import { store } from '~/store/store';
+
+function selectNextTaskInSortedOrder() {
+  const state = store.getState();
+  const sortedTasks = selectSortedTasks(state);
+  const selectedTaskId = selectSelectedTaskId(state);
+  
+  if (sortedTasks.length === 0) return;
+  
+  if (!selectedTaskId) {
+    store.dispatch(selectTaskById(sortedTasks[0].id));
+    return;
+  }
+  
+  const currentIndex = sortedTasks.findIndex(task => task.id === selectedTaskId);
+  if (currentIndex !== -1 && currentIndex < sortedTasks.length - 1) {
+    store.dispatch(selectTaskById(sortedTasks[currentIndex + 1].id));
+  }
+}
+
+function selectPreviousTaskInSortedOrder() {
+  const state = store.getState();
+  const sortedTasks = selectSortedTasks(state);
+  const selectedTaskId = selectSelectedTaskId(state);
+  
+  if (sortedTasks.length === 0) return;
+  
+  if (!selectedTaskId) {
+    store.dispatch(selectTaskById(sortedTasks[sortedTasks.length - 1].id));
+    return;
+  }
+  
+  const currentIndex = sortedTasks.findIndex(task => task.id === selectedTaskId);
+  if (currentIndex > 0) {
+    store.dispatch(selectTaskById(sortedTasks[currentIndex - 1].id));
+  }
+}
 
 // Undo
 export const taskUndoCommandData: CommandData = {
@@ -177,7 +214,7 @@ export const taskSelectNextCommandData: CommandData = {
 };
 export const taskSelectNextCommandCreator: CommandCreator = () => ({
   ...taskSelectNextCommandData,
-  action: () => store.dispatch(selectNextTask()),
+  action: selectNextTaskInSortedOrder,
   commandPalette: false,
 });
 
@@ -192,6 +229,6 @@ export const taskSelectPreviousCommandData: CommandData = {
 };
 export const taskSelectPreviousCommandCreator: CommandCreator = () => ({
   ...taskSelectPreviousCommandData,
-  action: () => store.dispatch(selectPreviousTask()),
+  action: selectPreviousTaskInSortedOrder,
   commandPalette: false,
 });

--- a/src/components/tasks/task-details.tsx
+++ b/src/components/tasks/task-details.tsx
@@ -18,9 +18,9 @@ import { useEffect, useMemo } from 'react';
 import { cn } from '~/lib/utils';
 import { TaskPrioritySelector } from './priority/task-priority-selector';
 import {
-  selectHasNextTask,
-  selectHasPreviousTask,
-} from '~/store/features/tasks/tasks-selectors';
+  selectHasNextSortedTask,
+  selectHasPreviousSortedTask,
+} from '~/store/features/display/display-selectors';
 import { RiCloseLine } from 'react-icons/ri';
 
 export type TaskDetailsProps = {
@@ -32,8 +32,8 @@ export function TaskDetails({ task }: TaskDetailsProps) {
 
   const dispatch = useAppDispatch();
 
-  const hasNextTask = useAppSelector(selectHasNextTask);
-  const hasPreviousTask = useAppSelector(selectHasPreviousTask);
+  const hasNextTask = useAppSelector(selectHasNextSortedTask);
+  const hasPreviousTask = useAppSelector(selectHasPreviousSortedTask);
   const taskSelectNextCommand = taskSelectNextCommandCreator();
   const taskSelectPreviousCommand = taskSelectPreviousCommandCreator();
   const taskDeleteCommand = useMemo(

--- a/src/store/features/display/display-selectors.ts
+++ b/src/store/features/display/display-selectors.ts
@@ -114,3 +114,33 @@ export const selectSortedTasks = createSelector(
     return sortedTasks;
   },
 );
+
+export const selectSortedTaskIndex = createSelector(
+  [selectSortedTasks, (state: RootState) => state.tasks.present.selectedTaskId],
+  function (sortedTasks, selectedTaskId) {
+    if (selectedTaskId == null) {
+      return -1;
+    }
+    return sortedTasks.findIndex((task) => task.id === selectedTaskId);
+  },
+);
+
+export const selectHasNextSortedTask = createSelector(
+  [selectSortedTasks, selectSortedTaskIndex],
+  function (sortedTasks, selectedIndex) {
+    if (selectedIndex === -1 || sortedTasks.length === 0) {
+      return false;
+    }
+    return selectedIndex < sortedTasks.length - 1;
+  },
+);
+
+export const selectHasPreviousSortedTask = createSelector(
+  [selectSortedTaskIndex],
+  function (selectedIndex) {
+    if (selectedIndex === -1) {
+      return false;
+    }
+    return selectedIndex > 0;
+  },
+);

--- a/src/store/features/display/display-slice.ts
+++ b/src/store/features/display/display-slice.ts
@@ -36,6 +36,7 @@ export interface DisplayState {
   sortBy: TaskSortField;
   sortDirection: TaskSortDirection;
   aiChatSidebarVisible: boolean;
+  sortFieldHidden: boolean;
 }
 
 const initialState: DisplayState = {
@@ -43,6 +44,7 @@ const initialState: DisplayState = {
   sortBy: 'title',
   sortDirection: 'desc',
   aiChatSidebarVisible: false,
+  sortFieldHidden: false,
 };
 
 export const displaySlice = createSlice({
@@ -56,10 +58,16 @@ export const displaySlice = createSlice({
       if (index === -1) {
         // Field is not visible, add it
         state.visibleFields.push(field);
+        if (field === state.sortBy) {
+          state.sortFieldHidden = false;
+        }
       } else {
         // Field is visible, remove it (but keep at least title)
         if (field !== 'title') {
           state.visibleFields.splice(index, 1);
+          if (field === state.sortBy) {
+            state.sortFieldHidden = true;
+          }
         }
       }
     },
@@ -74,7 +82,23 @@ export const displaySlice = createSlice({
       state.visibleFields = fields;
     },
     setSortBy: (state, action: PayloadAction<TaskSortField>) => {
-      state.sortBy = action.payload;
+      const newSortField = action.payload;
+      const currentSortField = state.sortBy;
+
+      if (state.sortFieldHidden && currentSortField !== 'title') {
+        const fieldIndex = state.visibleFields.indexOf(currentSortField);
+        if (fieldIndex !== -1) {
+          state.visibleFields.splice(fieldIndex, 1);
+        }
+      }
+
+      const isNewFieldHidden = !state.visibleFields.includes(newSortField);
+      if (isNewFieldHidden) {
+        state.visibleFields.push(newSortField);
+      }
+
+      state.sortBy = newSortField;
+      state.sortFieldHidden = isNewFieldHidden;
     },
     setSortDirection: (state, action: PayloadAction<TaskSortDirection>) => {
       state.sortDirection = action.payload;
@@ -86,6 +110,7 @@ export const displaySlice = createSlice({
       state.visibleFields = [...defaultVisibleFields];
       state.sortBy = initialState.sortBy;
       state.sortDirection = initialState.sortDirection;
+      state.sortFieldHidden = initialState.sortFieldHidden;
     },
     toggleAiChatSidebar: (state) => {
       state.aiChatSidebarVisible = !state.aiChatSidebarVisible;

--- a/src/store/features/tasks/tasks-selectors.ts
+++ b/src/store/features/tasks/tasks-selectors.ts
@@ -175,7 +175,7 @@ export const selectRecentlyUpdatedTasks = createSelector(
   },
 );
 
-// Navigation availability selectors
+// Navigation availability selectors (legacy)
 export const selectSelectedTaskIndex = createSelector(
   [selectAllTasks, selectSelectedTaskId],
   function (tasks, selectedTaskId) {

--- a/src/store/features/tasks/tasks-slice.ts
+++ b/src/store/features/tasks/tasks-slice.ts
@@ -105,41 +105,8 @@ export const tasksSlice = createSlice({
     clearSelectedTask: (state) => {
       state.selectedTaskId = null;
     },
-    selectNextTask: (state) => {
-      if (state.tasks.length === 0) return;
-
-      if (!state.selectedTaskId) {
-        // No task selected, select the first one
-        state.selectedTaskId = state.tasks[0].id;
-        return;
-      }
-
-      const currentIndex = state.tasks.findIndex(
-        (task) => task.id === state.selectedTaskId,
-      );
-      if (currentIndex !== -1 && currentIndex < state.tasks.length - 1) {
-        // Select the next task
-        state.selectedTaskId = state.tasks[currentIndex + 1].id;
-      }
-      // If already at the last task, do nothing (stay at current)
-    },
-    selectPreviousTask: (state) => {
-      if (state.tasks.length === 0) return;
-
-      if (!state.selectedTaskId) {
-        // No task selected, select the last one
-        state.selectedTaskId = state.tasks[state.tasks.length - 1].id;
-        return;
-      }
-
-      const currentIndex = state.tasks.findIndex(
-        (task) => task.id === state.selectedTaskId,
-      );
-      if (currentIndex > 0) {
-        // Select the previous task
-        state.selectedTaskId = state.tasks[currentIndex - 1].id;
-      }
-      // If already at the first task, do nothing (stay at current)
+    selectTaskById: (state, action: PayloadAction<string>) => {
+      state.selectedTaskId = action.payload;
     },
     resetTasks: (state) => {
       state.tasks = mockTasks;
@@ -157,13 +124,12 @@ export const {
   removeTaskLabel,
   setSelectedTask,
   clearSelectedTask,
-  selectNextTask,
-  selectPreviousTask,
+  selectTaskById,
   resetTasks,
 } = tasksSlice.actions;
 
 const undoableTasks = undoable(tasksSlice.reducer, {
-  groupBy: groupByActionTypes([selectNextTask.type, selectPreviousTask.type]),
+  groupBy: groupByActionTypes([selectTaskById.type]),
 });
 
 export default undoableTasks;


### PR DESCRIPTION
Changes made, with each change made in their own commit: 

1) Like Linear, should a hidden field be used for ordering, it will be shown temporarily then becomes hidden again when the hidden field changes. 

2) tooltips / labelling added for buttons for a11y

3) keyboard navigation changes. Navigation is now based on the sorted list. 

Since the ordering of lists is on the display layer in `selectSortedTasks` in `display-selectors.ts`, navigation has shifted away from `tasksSlice` to helper functions in `task-commands.tsx`

**Next Steps: **

Most of the changes from 3) have names like `selectHasNextSortedTask` / `selectPreviousTaskInSortedOrder` for now, but I think that the "sorted" portion of it should be omitted once the changes are okay