### PR TITLE
tasks: further misc changes to sorting logic

### DIFF
--- a/src/components/tasks/display/task-display-dropdown.tsx
+++ b/src/components/tasks/display/task-display-dropdown.tsx
@@ -146,7 +146,8 @@ export function TaskDisplayDropdown() {
                 <Button
                   variant="outline"
                   size="sm"
-                  className="h-6 px-1 text-xs w-16">
+                  className="h-6 px-1 text-xs w-16"
+                  tooltip={`Sort by ${fieldLabels[sortBy].toLowerCase()}`}>
                   <span>{fieldLabels[sortBy]}</span>
                 </Button>
               </DropdownMenuTrigger>
@@ -169,6 +170,8 @@ export function TaskDisplayDropdown() {
               }
               className="size-6 p-0 shrink-0"
               onClick={handleToggleSortDirection}
+              tooltip={`Sort ${sortDirection === 'asc' ? 'ascending' : 'descending'}`}
+              aria-label={`Sort ${sortDirection === 'asc' ? 'ascending' : 'descending'}`}
             />
           </div>
         </div>

--- a/src/store/features/display/display-slice.ts
+++ b/src/store/features/display/display-slice.ts
@@ -36,6 +36,7 @@ export interface DisplayState {
   sortBy: TaskSortField;
   sortDirection: TaskSortDirection;
   aiChatSidebarVisible: boolean;
+  sortFieldHidden: boolean;
 }
 
 const initialState: DisplayState = {
@@ -43,6 +44,7 @@ const initialState: DisplayState = {
   sortBy: 'title',
   sortDirection: 'desc',
   aiChatSidebarVisible: false,
+  sortFieldHidden: false,
 };
 
 export const displaySlice = createSlice({
@@ -56,10 +58,16 @@ export const displaySlice = createSlice({
       if (index === -1) {
         // Field is not visible, add it
         state.visibleFields.push(field);
+        if (field === state.sortBy) {
+          state.sortFieldHidden = false;
+        }
       } else {
         // Field is visible, remove it (but keep at least title)
         if (field !== 'title') {
           state.visibleFields.splice(index, 1);
+          if (field === state.sortBy) {
+            state.sortFieldHidden = true;
+          }
         }
       }
     },
@@ -74,7 +82,23 @@ export const displaySlice = createSlice({
       state.visibleFields = fields;
     },
     setSortBy: (state, action: PayloadAction<TaskSortField>) => {
-      state.sortBy = action.payload;
+      const newSortField = action.payload;
+      const currentSortField = state.sortBy;
+
+      if (state.sortFieldHidden && currentSortField !== 'title') {
+        const fieldIndex = state.visibleFields.indexOf(currentSortField);
+        if (fieldIndex !== -1) {
+          state.visibleFields.splice(fieldIndex, 1);
+        }
+      }
+
+      const isNewFieldHidden = !state.visibleFields.includes(newSortField);
+      if (isNewFieldHidden) {
+        state.visibleFields.push(newSortField);
+      }
+
+      state.sortBy = newSortField;
+      state.sortFieldHidden = isNewFieldHidden;
     },
     setSortDirection: (state, action: PayloadAction<TaskSortDirection>) => {
       state.sortDirection = action.payload;
@@ -86,6 +110,7 @@ export const displaySlice = createSlice({
       state.visibleFields = [...defaultVisibleFields];
       state.sortBy = initialState.sortBy;
       state.sortDirection = initialState.sortDirection;
+      state.sortFieldHidden = initialState.sortFieldHidden;
     },
     toggleAiChatSidebar: (state) => {
       state.aiChatSidebarVisible = !state.aiChatSidebarVisible;


### PR DESCRIPTION
Split the initial PR into 2. This contains the first 2 commits of 

1) Like Linear, should a hidden field be used for ordering, it will be shown temporarily then becomes hidden again when the hidden field changes.

2) tooltips / labelling added for buttons for a11y